### PR TITLE
Scraper fix + bold/italics support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/PuerkitoBio/goquery v1.6.0
 	github.com/spf13/cobra v1.1.1
+	golang.org/x/net v0.0.0-20220526153639-5463443f8c37
 )

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20220526153639-5463443f8c37 h1:lUkvobShwKsOesNfWWlCS5q7fnbG1MEliIzwu886fn8=
+golang.org/x/net v0.0.0-20220526153639-5463443f8c37/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -232,9 +234,13 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/query/scrape.go
+++ b/query/scrape.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+    "bytes"
 
 	"github.com/PuerkitoBio/goquery"
+    "golang.org/x/net/html"
 )
 
 func (data queryData) ScrapeLyrics() (lyrics string, err error) {
 
 	attempt := func() (string, error) {
-
 		res, err := http.Get("https://genius.com" + data.Path)
 		if err != nil {
 			return "", err
@@ -29,11 +30,47 @@ func (data queryData) ScrapeLyrics() (lyrics string, err error) {
 			return "", err
 		}
 
-		return strings.Trim(
-			doc.Find(".lyrics").
-				First().
-				Text(),
-			"\n "), nil
+        // inspired by goquery's Selection.Text() method but extended to support bold, italics, and newlines
+        // https://github.com/PuerkitoBio/goquery/blob/master/property.go#L62
+        var buf bytes.Buffer
+        var parse_node func(*html.Node)
+        parse_node = func(node *html.Node) {
+            switch node.Type {
+                case html.TextNode:
+                    buf.WriteString(node.Data)
+                    return
+                case html.ElementNode:
+                    var open_esc_code string
+                    var close_esc_code string
+
+                    switch node.Data {
+                        case "br":
+                            buf.WriteString("\n")
+                            return
+                        case "b":
+                            open_esc_code = "\033[1m"
+                            close_esc_code = "\033[22m"
+                        case "i":
+                            open_esc_code = "\033[3m"
+                            close_esc_code = "\033[23m"
+                    }
+
+                    if node.FirstChild != nil {
+                        buf.WriteString(open_esc_code)
+                        for child := node.FirstChild; child != nil; child = child.NextSibling {
+                            parse_node(child)
+                        }
+                        buf.WriteString(close_esc_code)
+                    }
+            }
+        }
+
+        sel := doc.Find("[data-lyrics-container=\"true\"]").First()
+        for _, node := range sel.Nodes {
+            parse_node(node)
+        }
+
+		return strings.Trim(buf.String(), "\n "), nil
 	}
 
 	for lyrics == "" {


### PR DESCRIPTION
Genius must have updated their HTML, so the lyrics are no longer in a class called "lyrics", but instead in a div with the data attribute `data-lyrics-container="true"`.

I also added ANSI escape codes for bold and italics, which is useful for when a verse has lyrics from multiple artists. Note that not all terminals support italics, but they should all support bold.

The original project has been archived so I'm making this PR in my fork instead.